### PR TITLE
Deploy Next.js control module at Vercel

### DIFF
--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -131,7 +131,7 @@ resource "vercel_deployment" "terrariaform_deploy" {
   ref = "master"
 }
 
-resource "vercel_project_domain" "name" {
+resource "vercel_project_domain" "terrariaform_domain" {
   project_id = vercel_project.terrariaform_web.id
   domain     = var.vercel_terrariaform_subdomain
 }

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -114,6 +114,28 @@ resource "aws_volume_attachment" "terrariaform_data_attach" {
   force_detach = true
 }
 
+resource "vercel_project" "terrariaform_web" {
+  name = "terrariaform-web"
+  framework = "nextjs"
+  root_directory = "services/web"
+
+  git_repository = {
+    type = "github"
+    repo = "Petri-Hub/terrariaform"
+  }
+}
+
+resource "vercel_deployment" "terrariaform_deploy" {
+  project_id = vercel_project.terrariaform_web.id
+  production = true
+  ref = "master"
+}
+
+resource "vercel_project_domain" "name" {
+  project_id = vercel_project.terrariaform_web.id
+  domain     = var.vercel_terrariaform_subdomain
+}
+
 resource "vercel_dns_record" "terraria_subdomain" {
   domain = var.vercel_domain_name
   type   = "A"
@@ -134,3 +156,4 @@ resource "supabase_project" "terrariaform" {
     prevent_destroy = true
   }
 }
+

--- a/cloud/terraform/variables.example.tfvars
+++ b/cloud/terraform/variables.example.tfvars
@@ -6,6 +6,7 @@ vercel_team_id =
 vercel_team_id =
 vercel_domain_name =
 vercel_terraria_subdomain =
+vercel_terrariaform_subdomain =
 supabase_access_token =
 supabase_db_password =
 supabase_region =

--- a/cloud/terraform/variables.tf
+++ b/cloud/terraform/variables.tf
@@ -31,7 +31,12 @@ variable "vercel_domain_name" {
 }
 
 variable "vercel_terraria_subdomain" {
-  description = "The subdomain for the Terraria server"
+  description = "The subdomain for the Terraria game server"
+  type        = string
+}
+
+variable "vercel_terrariaform_subdomain" {
+  description = "The subdomain for the Terrariaform website"
   type        = string
 }
 


### PR DESCRIPTION
This pull request introduces Terraform resources to deploy and manage the `terrariaform-web` project on Vercel, along with updates to variables and configurations to support this integration. The most important changes include adding Vercel resources for project, deployment, and domain management, and updating variable definitions and examples.

### Vercel Integration:

* Added `vercel_project`, `vercel_deployment`, and `vercel_project_domain` resources in `cloud/terraform/main.tf` to configure and deploy the `terrariaform-web` project on Vercel. This includes linking the project to a GitHub repository and setting up a custom subdomain.

### Variable Updates:

* Added `vercel_terrariaform_subdomain` variable in `cloud/terraform/variables.tf` to define the subdomain for the `terrariaform-web` website. Updated the description of `vercel_terraria_subdomain` for clarity.
* Updated `cloud/terraform/variables.example.tfvars` to include an example entry for `vercel_terrariaform_subdomain`.

### Minor Adjustments:

* Added a blank line for better readability after the `supabase_project` resource in `cloud/terraform/main.tf`.